### PR TITLE
Fixing missing AppController in CtkAppController

### DIFF
--- a/Controller/CtkAppController.php
+++ b/Controller/CtkAppController.php
@@ -17,6 +17,13 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
+App::uses('AppController', 'Controller');
+
+/**
+ * Abstract CTK controller.
+ *
+ * @package       Ctk.Controller
+ */
 abstract class CtkAppController extends AppController {
 
 /**

--- a/Test/Case/Controller/CtkAppControllerTest.php
+++ b/Test/Case/Controller/CtkAppControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Home controller for the Cake Toolkit.
+ *
+ * PHP 5
+ *
+ * Cake Toolkit (http://caketoolkit.org)
+ * Copyright 2012, James Watts (http://github.com/jameswatts)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2012, James Watts (http://github.com/jameswatts)
+ * @link          http://caketoolkit.org Cake Toolkit
+ * @package       Ctk.Controller
+ * @since         CakePHP(tm) v 2.2.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+
+App::uses('CtkAppController', 'Ctk.Controller');
+
+class TestingController extends CtkAppController {
+	
+
+}
+
+class CtkAppControllerTest extends CakeTestCase {
+
+/**
+ * Test if controller was enable to load AppController
+ * 
+ * @return void
+ */
+	public function testInstanceOfAppController() {
+		$controller = new TestingController();
+		$this->assertInstanceOf('AppController', $controller);
+		$this->assertInstanceOf('CtkAppController', $controller);
+	}
+
+}


### PR DESCRIPTION
I've used the CtkAppController in console command, I got one warning message about missing load/inclusion of AppController class. In this patch there is a simple test that shows the error, and the addition of missing App::use.
